### PR TITLE
Split webpack configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "build": "react-scripts build & tsc",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "start:renderer": "webpack --config webpack.app.js & node dist/renderer.js",
-    "start:server": "ts-node --project tsconfig.json ssr/index.ts",
+    "start:ssr": "webpack --config webpack.ssr.js & webpack --config webpack.react.js & node dist/ssr/main.js",
     "precommit": "lint-staged",
     "prepare": "husky install"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import reportWebVitals from './reportWebVitals';
 
 ReactDOM.hydrate(
   <React.StrictMode>
@@ -10,8 +9,3 @@ ReactDOM.hydrate(
   </React.StrictMode>,
   document.getElementById('root'),
 )
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();

--- a/ssr/routes/_common/utils.ts
+++ b/ssr/routes/_common/utils.ts
@@ -1,14 +1,30 @@
+import * as fs from 'fs';
+import path from 'path';
+
+const styleFiles = fs.readdirSync(path.resolve(__dirname, '../client/'))
+  .filter((file) => file.endsWith('.css'))
+  .map((file) => `<link rel="stylesheet" href="/resources/${file}"/>`)
+  .join('\n');
+
+const scriptFiles = fs.readdirSync(path.resolve(__dirname, '../client/'))
+  .filter((file) => file.endsWith('.js'))
+  .map((file) => {
+    const data = fs.readFileSync(path.resolve(`${__dirname}/../client`, file));
+    return `<script src="/resources/${file}"></script>`
+  }).join('\n');
+
 export const fillHtmlStub = (content: string, title: string) => {
-  return `<!DOCTYPE html>
+  return `
       <html lang="en">
         <head>
           <meta charset="UTF-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
           <title>${title}</title>
-         <link rel="stylesheet" href="/resources/style.css"/>
+          ${styleFiles}
         </head>
         <body>
           <div id="root">${content}</div>
+          ${scriptFiles}
         </body>
       </html>`;
 }

--- a/ssr/routes/resources/index.ts
+++ b/ssr/routes/resources/index.ts
@@ -1,11 +1,13 @@
 import fastifyStatic from '@fastify/static';
 import path from 'path';
 
+console.log(path.join(__dirname, '../client/'))
+
 const routes = [
   {
     plugin: fastifyStatic,
     opts: {
-      root: path.join(__dirname, '/resources'),
+      root: path.join(__dirname, '../client/'),
       prefix: '/resources/',
     },
     routeMeta: { path: '' },

--- a/webpack.react.js
+++ b/webpack.react.js
@@ -3,7 +3,7 @@ const CssExtract = require('mini-css-extract-plugin');
 
 module.exports = {
   mode: 'development',
-  entry: './src/App.tsx',
+  entry: './src/index.tsx',
   output: {
     filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist/client'),

--- a/webpack.react.js
+++ b/webpack.react.js
@@ -1,19 +1,10 @@
 const path = require('path');
-const nodeExternals = require('webpack-node-externals');
 const CssExtract = require('mini-css-extract-plugin');
 
 module.exports = {
-  // target: 'node',
-  // target: 'web',
   mode: 'development',
-  // devtool: 'inline-source-map',
-  // externalsPresets: {
-  //   node: true,
-  // },
-  // externals: [nodeExternals()],
   entry: './src/App.tsx',
   output: {
-    // filename: '[]client.js',
     filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist/client'),
   },

--- a/webpack.react.js
+++ b/webpack.react.js
@@ -3,23 +3,30 @@ const nodeExternals = require('webpack-node-externals');
 const CssExtract = require('mini-css-extract-plugin');
 
 module.exports = {
-  target: 'node',
+  // target: 'node',
+  // target: 'web',
   mode: 'development',
-  devtool: 'inline-source-map',
-  externalsPresets: {
-    node: true,
-  },
-  externals: [nodeExternals()],
-  entry: './ssr/index.ts',
+  // devtool: 'inline-source-map',
+  // externalsPresets: {
+  //   node: true,
+  // },
+  // externals: [nodeExternals()],
+  entry: './src/App.tsx',
   output: {
-    filename: 'renderer.js',
-    path: path.resolve(__dirname, 'dist'),
+    // filename: '[]client.js',
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, 'dist/client'),
   },
   plugins: [
     new CssExtract({
-      filename: 'resources/style.css',
+      filename: '[name].style.css',
     }),
   ],
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    }
+  },
   module: {
     rules: [
       {

--- a/webpack.ssr.js
+++ b/webpack.ssr.js
@@ -1,0 +1,83 @@
+const nodeExternals = require('webpack-node-externals');
+const path = require('path');
+const CssExtract = require('mini-css-extract-plugin');
+
+module.exports = {
+  target: 'node',
+  mode: 'development',
+  devtool: 'inline-source-map',
+  externalsPresets: {
+    node: true,
+  },
+  externals: [nodeExternals()],
+  entry: './ssr/index.ts',
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'dist/ssr'),
+  },
+  plugins: [
+    new CssExtract({
+      filename: 'style.css',
+      chunkFilename: '[name].css',
+    }),
+  ],
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          name: 'vendors',
+          test: /node_modules/,
+          chunks: 'all',
+          enforce: true,
+        },
+        styles: {
+          name: 'styles',
+          test: /.css/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        use: 'ts-loader',
+        exclude: [
+          /node_modules/,
+        ],
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: [
+          /node_modules/,
+        ],
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              '@babel/preset-env',
+              '@babel/preset-react',
+            ],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [
+          CssExtract.loader,
+          'css-loader',
+        ],
+      },
+      {
+        test: /\.svg$/,
+        loader: '@svgr/webpack',
+        issuer: /\.(js|ts)x?$/,
+      }
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.ts', '.tsx', '.jsx'],
+  },
+}


### PR DESCRIPTION
Configurations for server and React client app have some differences, so splitting the webpack config in two sounds like a sensible idea. Too bad most SSR guides don't mention it.